### PR TITLE
Switch to sane pipe impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,16 +52,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-pipe"
-version = "0.1.3"
-source = "git+https://github.com/alecmocatta/async-pipe-rs#40ce08083ed02519372314eff8030c4b8c4da4b2"
-dependencies = [
- "futures",
- "log",
- "tokio",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,6 +158,7 @@ dependencies = [
  "once_cell",
  "regex",
  "terminal_size",
+ "unicode-width",
  "winapi",
 ]
 
@@ -682,13 +673,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.0-rc.1"
+version = "0.17.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c112b1e714737c51fa137aaf6ae2cdf6960d01895e096a6feb1e0afd192c790d"
+checksum = "bcff4a3e20f61e89b1560f96ce23f3943ea58fd71ef8c9c028e56436da02e37b"
 dependencies = [
  "console",
  "number_prefix",
  "tokio",
+ "unicode-width",
 ]
 
 [[package]]
@@ -727,7 +719,6 @@ version = "0.2.4"
 dependencies = [
  "argh",
  "async-compression",
- "async-pipe",
  "base-x",
  "bytes 1.1.0",
  "dotenv",
@@ -1610,6 +1601,12 @@ name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ publish = true
 [dependencies]
 argh = "0.1"
 async-compression = { version = "0.3", features = ["tokio", "zstd"] }
-async-pipe = { version = "0.1", features = ["tokio"], git = "https://github.com/alecmocatta/async-pipe-rs" }
 base-x = "0.2"
 bytes = "1"
 dotenv = "0.15.0"
@@ -20,7 +19,7 @@ envy = "0.4"
 filetime = "0.2"
 futures = "0.3"
 home = "0.5"
-indicatif = { version = "0.17.0-rc.1", features = ["tokio"] }
+indicatif = { version = "0.17.0-rc.4", features = ["tokio"] }
 pin-project = "1"
 rand = "0.8"
 rusoto_core = { version = "0.47", default-features = false, features = ["rustls"] }

--- a/src/tar.rs
+++ b/src/tar.rs
@@ -66,7 +66,7 @@ pub fn walk(
 }
 
 pub fn tar(paths: impl Iterator<Item = FilePathInfo>) -> impl AsyncRead {
-    let (writer, reader) = async_pipe::pipe();
+    let (writer, reader) = tokio::io::duplex(16 * 1024 * 1024);
     let task = async move {
         // create a .tar.zsd
         // FIXME: switch to a threaded implementation using std::io::Write, rather than


### PR DESCRIPTION
[`async_pipe`](https://github.com/routerify/async-pipe-rs) is surprisingly badly impld. Switch to tokio's, which I'd overlooked before.

From:
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/1136246/154812271-ece5ca78-557f-4920-bf87-01c73f0eecb2.png">

To:
<img width="1192" alt="image" src="https://user-images.githubusercontent.com/1136246/154812310-697ae9b2-8ad0-4c9f-9fac-5f7dc2ded7b0.png">
